### PR TITLE
Removes Prism syntax highlighting CSS

### DIFF
--- a/code/scss/global.scss
+++ b/code/scss/global.scss
@@ -1,7 +1,7 @@
 @import "_settings";
 @import "_colours";
 @import "_grid";
-@import "_prism";
+// @import "_prism";
 
 @font-face {
     font-family: 'rubikmedium';

--- a/code/scss/global.scss
+++ b/code/scss/global.scss
@@ -1,7 +1,6 @@
 @import "_settings";
 @import "_colours";
 @import "_grid";
-// @import "_prism";
 
 @font-face {
     font-family: 'rubikmedium';


### PR DESCRIPTION
This syntax highlighting isn't currently being used - but is in the CSS. I'm removing it to decrease the CSS file size.