### PR TITLE
Update caonical URL logic in site data

### DIFF
--- a/_data/site.js
+++ b/_data/site.js
@@ -1,9 +1,7 @@
 const site = {
   // all the defaults
   locale: 'en-GB',
-  baseURL: process.env.DEPLOY_PRIME_URL ? process.env.DEPLOY_PRIME_URL : 'https://inj.ms',
-  siteName: 'inj.ms',
-  siteTitle: 'Ian makes things for the web',
+  baseURL: process.env.CONTEXT === 'production' ? 'https://inj.ms' : process.env.DEPLOY_PRIME_URL,
   themeColour: '#f9bf3b',
   twitter: {
     cardType: 'summary',


### PR DESCRIPTION
The environment variable `DEPLOY_PRIME_URL` returns `https://primary--injms.netlify.app` instead of  the hoped for`https://inj.ms` - this fixes that to return `inj.ms` for production instead of the Netlify deployment URL.