### PR TITLE
Update visual regression test workflow

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: percy/snapshot-action@v0.1.2
-      with:
-        build-directory: "site/"
+    - run: npx percy snapshot site/
       env:
         PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"


### PR DESCRIPTION
The Percy GitHub Action is deprecated[^1] - the new suggestion is to use `npx percy snapshot {{ folder }}` directly in the workflow[^2].

[^1]: https://github.com/percy/snapshot-action#deprecated
[^2]: https://github.com/percy/snapshot-action#after