### PR TITLE
Replace the Percy agent with new Percy CLI

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: npx percy snapshot site/
+    - run: npx @percy/cli snapshot site/
       env:
         PERCY_TOKEN: "${{ secrets.PERCY_TOKEN }}"

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,2 +1,6 @@
+version: 2
 snapshot:
-  widths: [360, 800, 1280]
+  widths:
+    - 360
+    - 800
+    - 1280


### PR DESCRIPTION
Replaces the use of the old Percy agent with the new Percy CLI.

Confusingly, the Percy docs advised to use `npx percy...` - which points at a deprecated version of the Percy agent[^1]. Instead, the namespaced Percy CLI[^2] should've been used.

[^1]: https://npmjs.com/packages/percy
[^2]: https://www.npmjs.com/package/@percy/cli
