### PR TITLE
fix: remove twitter metadata and shortlink

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -104,11 +104,6 @@
     status = 302
 
 [[redirects]]
-    from = "/twitter"
-    to = "https://twitter.com/_injms_"
-    status = 302
-
-[[redirects]]
     from = "/copyright"
     to = "https://www.ianjamesphotography.com/copyright"
     status = 302

--- a/site/index.html
+++ b/site/index.html
@@ -21,13 +21,6 @@
 
     <meta name="description" content="I&#39;m Ian and I wear many hats of many colours - though usually I&#39;m found wearing my front end developer trilby or my parental hard hat.">
 
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="@_injms_">
-    <meta name="twitter:creator" content="@_injms_">
-    <meta name="twitter:url" content="https://inj.ms">
-    <meta name="twitter:title" content="Ian makes things for the web.">
-    <meta name="twitter:description" content="I&#39;m Ian and I wear many hats of many colours - though usually I&#39;m found wearing my front end developer trilby or my parental hard hat.">
-
     <meta property="og:url" content="https://inj.ms">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Ian makes things for the web.">


### PR DESCRIPTION
Twitter falls back to the Open Graph, so it's not necessary to have both sets of metadata. Plus I don't use Twitter any more for *cough* obvious reasons.